### PR TITLE
Add an html escaping function

### DIFF
--- a/repo/webadmin/web/ajax/dashboard.html
+++ b/repo/webadmin/web/ajax/dashboard.html
@@ -406,13 +406,13 @@
             });
         });     
     }
-    
+
     function get_log(isolate_uuid, log_id) {
         $('#isolate_modal_ajax-content_logs').html('<img src="img/devoops_getdata.gif"  alt="preloader"/>');   
         $.getJSON( "/debug/api/v1/isolates/"+isolate_uuid+"/logs/"+log_id, function( data ) { 
             var content = "<p><br/><a class='btn btn-default' id='link_get_logs' href='#' data-uuid='"+isolate_uuid+"'>&lt; Logs list</a> ";
             content += " <a href='/debug/api/v1/isolates/"+isolate_uuid+"/logs/"+log_id+"?raw' target='_blanc' class='btn btn-default'>Open in a seperate window</a></p>";
-            content += "<pre>" + data["log"] + "</pre>";                                           
+            content += "<pre>" + escapeHTML(data["log"]) + "</pre>";
             $('#isolate_modal_ajax-content_logs').html(content);
             $("#link_get_logs").click(function(event) {
                 console.log("link_get_logs clicked!");

--- a/repo/webadmin/web/js/webadmin.js
+++ b/repo/webadmin/web/js/webadmin.js
@@ -148,6 +148,10 @@ function CloseModalBox(){
 	});
 }
 
+function escapeHTML(html) {
+	return html.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
 //////////////////////////////////////////////////////
 //////////////////////////////////////////////////////
 //


### PR DESCRIPTION
The representation (```__repr__(self)```) of many python objects are done using the following syntax : "\<path.to.Class Object at 0xfffffffff \>". Therefore, it creates html tags in the log files. 

Before displaying the logs in the webadmin, these tags needs to be escaped.