### PR TITLE
Add herald namespace to OSGi shell in the configuration file.

### DIFF
--- a/conf/herald/java-core.js
+++ b/conf/herald/java-core.js
@@ -9,5 +9,7 @@
 		"name" : "org.cohorte.herald.api"
 	}, {
 		"name" : "org.cohorte.herald.core"
+	}, { 
+		"name" : "org.cohorte.herald.shell"
 	} ]
 }


### PR DESCRIPTION
Activated commands are:
* `herald:fire`
* `herald:local`
* `herald:peers`